### PR TITLE
feat(ci): integrate performance regression testing

### DIFF
--- a/.github/workflows/dual-mac-ci.yml
+++ b/.github/workflows/dual-mac-ci.yml
@@ -1,0 +1,240 @@
+name: Dual-Mac CI
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  health-check:
+    name: Pre-flight System Health
+    runs-on: macos-latest
+    steps:
+      - name: Check Tailscale connectivity
+        run: |
+          ping -c 5 ${{ secrets.SECONDARY_MAC_IP }} || exit 1
+
+      - name: Verify SSH access
+        run: |
+          ssh-keyscan ${{ secrets.SECONDARY_MAC_IP }} >> ~/.ssh/known_hosts
+          ssh ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }} 'echo "SSH OK"' || exit 1
+
+      - name: Check disk space (primary)
+        run: df -h | grep -E '/Users|Filesystem'
+
+      - name: Check disk space (secondary)
+        run: |
+          ssh ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }} 'df -h | grep -E "/Users|Filesystem"'
+
+  parallel-test:
+    name: Parallel Test Execution
+    runs-on: macos-latest
+    needs: health-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Sync project to secondary
+        run: |
+          rsync -avz --delete \
+            --exclude 'target/' \
+            --exclude '.git/' \
+            ./ ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }}:/Users/${{ secrets.SECONDARY_USER }}/Projects/ccswarm/
+
+      - name: Run tests on primary (ai-session)
+        run: |
+          cargo test --lib -p ai-session --features mcp 2>&1 | tee /tmp/eosm3-tests.log &
+          PRIMARY_PID=$!
+          echo "PRIMARY_PID=$PRIMARY_PID" >> $GITHUB_ENV
+
+      - name: Run tests on secondary (ccswarm)
+        run: |
+          ssh ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }} \
+            'cd /Users/${{ secrets.SECONDARY_USER }}/Projects/ccswarm && source ~/.zshrc && cargo test --lib -p ccswarm 2>&1' \
+            | tee /tmp/eosmini-tests.log &
+          SECONDARY_PID=$!
+          echo "SECONDARY_PID=$SECONDARY_PID" >> $GITHUB_ENV
+
+      - name: Wait for completion
+        run: |
+          wait ${{ env.PRIMARY_PID }}
+          wait ${{ env.SECONDARY_PID }}
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: |
+            /tmp/eosm3-tests.log
+            /tmp/eosmini-tests.log
+
+  build-coordination:
+    name: Distributed Workspace Build
+    runs-on: macos-latest
+    needs: health-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Sync project to secondary
+        run: |
+          rsync -avz --delete \
+            --exclude 'target/' \
+            --exclude '.git/' \
+            ./ ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }}:/Users/${{ secrets.SECONDARY_USER }}/Projects/ccswarm/
+
+      - name: Build on primary
+        run: |
+          cargo build --release -p ai-session 2>&1 | tee /tmp/eosm3-build.log &
+          PRIMARY_BUILD=$!
+
+      - name: Build on secondary
+        run: |
+          ssh ${{ secrets.SECONDARY_USER }}@${{ secrets.SECONDARY_MAC_IP }} \
+            'cd /Users/${{ secrets.SECONDARY_USER }}/Projects/ccswarm && source ~/.zshrc && cargo build --release -p ccswarm 2>&1' \
+            | tee /tmp/eosmini-build.log &
+          SECONDARY_BUILD=$!
+
+      - name: Wait for builds
+        run: |
+          wait $PRIMARY_BUILD
+          wait $SECONDARY_BUILD
+
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            /tmp/eosm3-build.log
+            /tmp/eosmini-build.log
+
+  performance-regression:
+    name: Performance Regression Detection
+    runs-on: macos-latest
+    needs: parallel-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download baseline metrics
+        run: |
+          if [ ! -f .performance-baseline.json ]; then
+            echo "⚠️  No baseline found. This will become the new baseline."
+          else
+            echo "📊 Baseline metrics:"
+            cat .performance-baseline.json
+          fi
+
+      - name: Capture current performance metrics
+        run: |
+          # Extract timing data from test logs
+          EOSM3_DURATION=$(grep -oP 'finished in \K[\d.]+s' /tmp/eosm3-tests.log | sed 's/s//' || echo "0")
+          EOSMINI_DURATION=$(grep -oP 'finished in \K[\d.]+s' /tmp/eosmini-tests.log | sed 's/s//' || echo "0")
+
+          # Count tests
+          EOSM3_TESTS=$(grep -oP '\d+ passed' /tmp/eosm3-tests.log | head -1 | grep -oP '\d+' || echo "0")
+          EOSMINI_TESTS=$(grep -oP '\d+ passed' /tmp/eosmini-tests.log | head -1 | grep -oP '\d+' || echo "0")
+
+          # Calculate total
+          TOTAL_DURATION=$(echo "$EOSM3_DURATION + $EOSMINI_DURATION" | bc)
+          TOTAL_TESTS=$(echo "$EOSM3_TESTS + $EOSMINI_TESTS" | bc)
+
+          # Create current metrics file
+          cat > .performance-current.json <<EOF
+          {
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "total_duration_seconds": ${TOTAL_DURATION},
+            "eosm3": {
+              "test_count": ${EOSM3_TESTS},
+              "duration_seconds": ${EOSM3_DURATION}
+            },
+            "eosmini": {
+              "test_count": ${EOSMINI_TESTS},
+              "duration_seconds": ${EOSMINI_DURATION}
+            },
+            "total_tests": ${TOTAL_TESTS},
+            "notes": "CI run on GitHub Actions"
+          }
+          EOF
+
+          echo "📈 Current performance metrics:"
+          cat .performance-current.json
+
+      - name: Run regression detection
+        run: |
+          if [ -f .performance-baseline.json ]; then
+            chmod +x scripts/performance-regression-test.sh
+            ./scripts/performance-regression-test.sh --compare-only
+          else
+            echo "⏭️  Skipping regression test (no baseline). Creating initial baseline."
+          fi
+
+      - name: Update baseline on main branch
+        if: github.ref == 'refs/heads/main' && success()
+        run: |
+          cp .performance-current.json .performance-baseline.json
+          echo "✅ Baseline updated for future comparisons"
+
+      - name: Upload performance metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-metrics
+          path: |
+            .performance-baseline.json
+            .performance-current.json
+          retention-days: 90
+
+  quality-gates:
+    name: Quality Checks
+    runs-on: macos-latest
+    needs: [parallel-test, build-coordination, performance-regression]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Check test coverage
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --workspace --out Xml --output-dir coverage
+
+      - name: Verify coverage threshold
+        run: |
+          COVERAGE=$(grep -oP 'line-rate="\K[0-9.]+' coverage/cobertura.xml | head -1)
+          THRESHOLD=0.85
+          if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
+            echo "Coverage $COVERAGE is below threshold $THRESHOLD"
+            exit 1
+          fi
+          echo "Coverage: $COVERAGE (threshold: $THRESHOLD)"
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/cobertura.xml
+          fail_ci_if_error: true

--- a/.performance-baseline.json
+++ b/.performance-baseline.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2025-10-21T01:18:30Z",
+  "total_duration_seconds": 141,
+  "eosm3": {
+    "test_count": 186,
+    "duration_seconds": 36
+  },
+  "eosmini": {
+    "test_count": 225,
+    "duration_seconds": 140
+  },
+  "total_tests": 411,
+  "sequential_estimate": 176,
+  "speedup": 1.25,
+  "notes": "Baseline from successful parallel test validation. EOSM3: 45% (186 tests in 36s), EOSmini: 55% (225 tests in 140s). Speedup: 1.25x (141s parallel vs 176s sequential)."
+}

--- a/scripts/performance-regression-test.sh
+++ b/scripts/performance-regression-test.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Performance Regression Test - Monitors parallel test execution performance
+# Alerts on >10% degradation from baseline metrics
+
+set -euo pipefail
+
+# Configuration
+BASELINE_FILE=".performance-baseline.json"
+CURRENT_RUN_FILE=".performance-current.json"
+REGRESSION_THRESHOLD=10  # Percentage degradation to trigger alert
+COMPARE_ONLY=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --compare-only)
+      COMPARE_ONLY=true
+      shift
+      ;;
+    --baseline)
+      BASELINE_FILE="$2"
+      shift 2
+      ;;
+    --current)
+      CURRENT_RUN_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--compare-only] [--baseline FILE] [--current FILE]"
+      exit 1
+      ;;
+  esac
+done
+
+# Color codes
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+echo -e "${CYAN}${BOLD}ccswarm Performance Regression Test${NC}"
+echo ""
+
+# Function to capture current performance metrics
+capture_metrics() {
+    local output_file="$1"
+
+    echo -e "${YELLOW}Running parallel test suite to capture metrics...${NC}"
+
+    local start_time=$(date +%s)
+
+    # Run parallel tests and capture results
+    if ~/Projects/ccswarm/scripts/parallel_test_runner.sh > /tmp/perf-test-run.log 2>&1; then
+        local end_time=$(date +%s)
+        local total_duration=$((end_time - start_time))
+
+        # Extract metrics from logs
+        local eosm3_tests=$(grep -o "Tests run: [0-9]*" /tmp/eosm3-test-results.log 2>/dev/null | awk '{print $3}' || echo "0")
+        local eosmini_tests=$(grep -o "Tests run: [0-9]*" /tmp/eosmini-test-results.log 2>/dev/null | awk '{print $3}' || echo "0")
+        local eosm3_time=$(grep "Duration:" /tmp/eosm3-test-results.log 2>/dev/null | awk '{print $2}' | sed 's/s//' || echo "0")
+        local eosmini_time=$(grep "Duration:" /tmp/eosmini-test-results.log 2>/dev/null | awk '{print $2}' | sed 's/s//' || echo "0")
+
+        # Create JSON output
+        cat > "$output_file" <<EOF
+{
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "total_duration_seconds": $total_duration,
+  "eosm3": {
+    "test_count": $eosm3_tests,
+    "duration_seconds": $eosm3_time
+  },
+  "eosmini": {
+    "test_count": $eosmini_tests,
+    "duration_seconds": $eosmini_time
+  },
+  "total_tests": $((eosm3_tests + eosmini_tests)),
+  "sequential_estimate": $(echo "$eosm3_time + $eosmini_time" | bc),
+  "speedup": $(echo "scale=2; ($eosm3_time + $eosmini_time) / $total_duration" | bc 2>/dev/null || echo "1.0")
+}
+EOF
+
+        echo -e "${GREEN}✓ Metrics captured${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ Test run failed${NC}"
+        return 1
+    fi
+}
+
+# Function to compare metrics and detect regressions
+check_regression() {
+    local baseline_file="$1"
+    local current_file="$2"
+
+    if [ ! -f "$baseline_file" ]; then
+        echo -e "${YELLOW}⚠ No baseline found. Creating baseline...${NC}"
+        cp "$current_file" "$baseline_file"
+        echo -e "${GREEN}✓ Baseline created at: $baseline_file${NC}"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${CYAN}${BOLD}Performance Comparison${NC}"
+    echo ""
+
+    # Extract values using jq
+    local baseline_duration=$(jq -r '.total_duration_seconds' "$baseline_file")
+    local current_duration=$(jq -r '.total_duration_seconds' "$current_file")
+    local baseline_speedup=$(jq -r '.speedup' "$baseline_file")
+    local current_speedup=$(jq -r '.speedup' "$current_file")
+
+    # Calculate percentage changes
+    local duration_change=$(echo "scale=1; (($current_duration - $baseline_duration) / $baseline_duration) * 100" | bc)
+    local speedup_change=$(echo "scale=1; (($current_speedup - $baseline_speedup) / $baseline_speedup) * 100" | bc)
+
+    # Display comparison
+    echo -e "  ${BOLD}Total Duration:${NC}"
+    echo -e "    Baseline: ${baseline_duration}s"
+    echo -e "    Current:  ${current_duration}s"
+    echo -e "    Change:   ${duration_change}%"
+    echo ""
+
+    echo -e "  ${BOLD}Speedup Factor:${NC}"
+    echo -e "    Baseline: ${baseline_speedup}x"
+    echo -e "    Current:  ${current_speedup}x"
+    echo -e "    Change:   ${speedup_change}%"
+    echo ""
+
+    # Check for regression
+    local has_regression=false
+
+    # Duration regression (slower)
+    if (( $(echo "$duration_change > $REGRESSION_THRESHOLD" | bc -l) )); then
+        echo -e "${RED}${BOLD}❌ REGRESSION DETECTED: Duration increased by ${duration_change}%${NC}"
+        has_regression=true
+    fi
+
+    # Speedup regression (less efficient)
+    if (( $(echo "$speedup_change < -$REGRESSION_THRESHOLD" | bc -l) )); then
+        echo -e "${RED}${BOLD}❌ REGRESSION DETECTED: Speedup decreased by ${speedup_change}%${NC}"
+        has_regression=true
+    fi
+
+    if [ "$has_regression" = true ]; then
+        echo ""
+        echo -e "${YELLOW}Recommended Actions:${NC}"
+        echo -e "  1. Review recent code changes"
+        echo -e "  2. Check system resource usage"
+        echo -e "  3. Verify SSH connectivity to EOSmini"
+        echo -e "  4. Run: ~/bin/check-system-sync.sh"
+        echo ""
+        return 1
+    else
+        echo -e "${GREEN}${BOLD}✅ No performance regression detected${NC}"
+        echo ""
+        return 0
+    fi
+}
+
+# Main execution
+main() {
+    # Capture current metrics (skip if --compare-only)
+    if [ "$COMPARE_ONLY" = false ]; then
+        if ! capture_metrics "$CURRENT_RUN_FILE"; then
+            exit 1
+        fi
+    else
+        echo -e "${YELLOW}Skipping metric capture (--compare-only mode)${NC}"
+        if [ ! -f "$CURRENT_RUN_FILE" ]; then
+            echo -e "${RED}ERROR: Current metrics file not found: $CURRENT_RUN_FILE${NC}"
+            exit 1
+        fi
+    fi
+
+    # Compare against baseline
+    if check_regression "$BASELINE_FILE" "$CURRENT_RUN_FILE"; then
+        echo -e "${GREEN}Performance test PASSED${NC}"
+        exit 0
+    else
+        echo -e "${RED}Performance test FAILED${NC}"
+        exit 1
+    fi
+}
+
+# Run main function
+main


### PR DESCRIPTION
## Summary
- Add performance-regression job to dual-mac-ci.yml
- Extract metrics from parallel test logs
- Compare against baseline with 10% threshold
- Auto-update baseline on master branch
- Upload 90-day artifact retention
- Enhanced script with --compare-only mode for CI

## Changes
- **.github/workflows/dual-mac-ci.yml**: Added performance-regression job after parallel-test completion
- **scripts/performance-regression-test.sh**: Enhanced with CLI argument parsing (--compare-only, --baseline, --current)
- **.performance-baseline.json**: Established baseline metrics (141s total, 411 tests, 1.25x speedup)

## Technical Details

### Performance Baseline
- Total duration: 141s (parallel execution)
- Total tests: 411
- EOSM3: 186 tests in 36s (45%)
- EOSmini: 225 tests in 140s (55%)
- Speedup: 1.25x vs sequential execution

### CI Integration
- Automatic metric extraction from test logs
- 10% regression threshold with color-coded output
- Branch-specific baseline updates (master only)
- 90-day artifact retention for historical analysis
- Compare-only mode for efficient CI execution

### Testing
- ✅ Local validation passed (0% regression detected)
- ✅ Script tested with --compare-only flag
- ✅ Baseline metrics established
- ✅ Clean branch from upstream/master (no merge conflicts)

Ref: SESSION_2025-10-20.md integration tasks