### PR TITLE
fix(build): stop gating 17 cross-platform deps behind cfg(unix) (fixes Windows build)

### DIFF
--- a/crates/ccswarm/Cargo.toml
+++ b/crates/ccswarm/Cargo.toml
@@ -67,10 +67,6 @@ opentelemetry-otlp = { version = "0.32.0", features = [
 tracing-opentelemetry = { version = "0.33.0", optional = true }
 
 
-# Process management
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["fs", "process"] }
-
 # Configuration
 config = "0.15"
 
@@ -121,6 +117,10 @@ secrecy = { version = "0.10", features = ["serde"] }
 
 # Directory paths
 dirs = "6.0"
+
+# Process management (Unix-only: nix has no Windows support)
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["fs", "process"] }
 
 [dev-dependencies]
 # Testing


### PR DESCRIPTION
## Problem

`crates/ccswarm/Cargo.toml` declares `[target.'cfg(unix)'.dependencies]` partway down the dependency list (line 71). Every dependency added below it has silently inherited the Unix gate.

Only `nix` is genuinely Unix-only. The other 17 are cross-platform:

`config`, `async-channel`, `dashmap`, `reqwest`, `tempfile`, `async-trait`, `futures`, `log`, `bollard`, `futures-util`, `tar`, `urlencoding`, `colored`, `rand`, `sysinfo`, `secrecy`, `dirs`

On Windows those crates are absent from the dependency graph entirely, so roughly half the tree vanishes and the build fails:

```
error[E0433]: cannot find module or crate `reqwest`
error[E0433]: cannot find module or crate `colored`
error[E0433]: cannot find module or crate `dirs`
...
error: could not compile `ccswarm` (lib) due to 629 previous errors
```

The `E0433`s cascade into several hundred `E0432`/`E0277`/`E0308`/`E0599` follow-ons.

This looks like ordinary drift rather than intent — `nix` was added under the gate, and later dependencies were appended beneath it. CI runs on `ubuntu-latest` only, where `cfg(unix)` is a no-op, so nothing caught it.

## Fix

Move `nix` into its own `cfg(unix)` block placed after the shared dependencies, so everything else falls under plain `[dependencies]`.

**4 insertions, 4 deletions, one file. No code changes.**

## Verification

Target `x86_64-pc-windows-gnu`, rustc 1.97.1, MinGW-w64 16.2.0 (msvcrt):

| | Before | After |
|---|---|---|
| `cargo check --release` | 629 errors | — |
| `cargo build --release` | fails | **clean, 2m45s** |

Post-fix the binary runs: `ccswarm doctor` reports all systems operational, `flow list` shows all 6 builtin flows, and `pipeline --dry-run` composes prompts correctly through the plan / sangha / member stages.

Unix builds are unaffected — the same 17 crates resolve identically whether or not they sit under the gate, and `nix` remains Unix-gated.

## Note on Windows support generally

I don't know whether Windows is a platform you intend to support. If it is, adding `windows-latest` to the CI matrix would prevent this class of regression — this specific bug is invisible to a Linux-only matrix. If it isn't, this change is still harmless on Unix and costs nothing.

One thing outside the scope of this PR: rustup's bundled MinGW omits `as.exe`, so `dlltool` cannot build import libraries and the build fails earlier with `dlltool.exe: CreateProcess`. A full MinGW-w64 toolchain fixes that. Worth a README line if you do take Windows support.